### PR TITLE
fix: dir listings need sorting

### DIFF
--- a/deepdream.py
+++ b/deepdream.py
@@ -119,7 +119,7 @@ def deep_dream_video(config):
     metadata = video_utils.dump_frames(video_path, tmp_input_dir)
 
     last_img = None
-    for frame_id, frame_name in enumerate(os.listdir(tmp_input_dir)):
+    for frame_id, frame_name in enumerate(sorted(os.listdir(tmp_input_dir))):
         print(f'Processing frame {frame_id}')
         frame_path = os.path.join(tmp_input_dir, frame_name)
         frame = utils.load_image(frame_path, target_shape=config['img_width'])

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -13,7 +13,7 @@ def valid_frames(input_dir):
     def valid_frame_name(str):
         pattern = re.compile(r'[0-9]{6}\.jpg')  # regex, examples it covers: 000000.jpg or 923492.jpg, etc.
         return re.fullmatch(pattern, str) is not None
-    candidate_frames = os.listdir(input_dir)
+    candidate_frames = sorted(os.listdir(input_dir))
     valid_frames = list(filter(valid_frame_name, candidate_frames))
     return valid_frames
 
@@ -78,7 +78,7 @@ def dump_frames(video_path, dump_dir):
 def create_gif(frames_dir, out_path):
     assert os.path.splitext(out_path)[1].lower() == '.gif', f'Expected gif got {os.path.splitext(out_path)[1]}.'
 
-    frame_paths = [os.path.join(frames_dir, frame_name) for frame_name in os.listdir(frames_dir) if frame_name.endswith('.jpg')]
+    frame_paths = [os.path.join(frames_dir, frame_name) for frame_name in sorted(os.listdir(frames_dir)) if frame_name.endswith('.jpg')]
     images = [imageio.imread(frame_path) for frame_path in frame_paths]
     imageio.mimwrite(out_path, images, fps=10)
     print(f'Saved gif to {out_path}.')


### PR DESCRIPTION
`os.listdir` returns an arbitrarily ordered list that's dependant on how your system indexes files. When generating videos on my system the files are processed in random order and the frames are stitched back together in the wrong order.